### PR TITLE
meson.build fixups

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -271,30 +271,19 @@ endif
 # Display final informations about configuration
 # ==============================================
 
-#TODO use summary()
-lines = [
-    'prefix:    ' + get_option('prefix'),
-    'libdir:    ' + get_option('libdir'),
-    '',
-]
+summary({
+  'prefix': get_option('prefix'),
+  'libdir': get_option('libdir'),
+  'debug': get_option('debug'),
+  'docs': get_option('docs'),
+  'tests': get_option('tests'),
+  'tools': get_option('tools')},
+  section: 'Project options'
+)
 
-lines += 'debug:       ' + (get_option('debug') ? 'yes' : 'no')
-lines += 'docs:        ' + (get_option('docs') ? 'yes' : 'no')
-lines += 'tests:       ' + (get_option('tests') ? 'yes' : 'no')
-lines += 'tools:       ' + (get_option('tools') ? 'yes' : 'no')
-lines += 'werror:      ' + (get_option('werror') ? 'yes' : 'no')
-lines += 'weffc:       ' + (get_option('weffc') ? 'yes' : 'no')
-lines += 'wparanoic:   ' + (get_option('wparanoic') ? 'yes' : 'no')
-
-
-indent = '    '
-
-params = indent + ('\n' + indent + ('\n' + indent).join(lines))
-
-build_config_info = ('\n\n')
-build_config_info += ('==============================================================================\n')
-build_config_info += ('Build configuration:\n')
-build_config_info += ('@0@\n\n'.format(params))
-build_config_info += ('==============================================================================\n')
-
-message(build_config_info)
+summary({
+  'werror': get_option('werror'),
+  'weffc': get_option('weffc'),
+  'wparanoic': get_option('wparanoic')},
+  section: 'Compiler options'
+)

--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@
 project(
     'libone',
     ['cpp'],
-    version : '0.1.0',
+    version : '0.0.90',
     license : 'MPL 2.0+',
     default_options : [
         'cpp_std=c++11',

--- a/src/lib/meson.build
+++ b/src/lib/meson.build
@@ -66,6 +66,7 @@ libone_include_directory = '../../inc/'
 libone_target = library(
   'one',
   libone_source_files,
+  version : meson.project_version(),
   install : true,
   dependencies : libone_source_dependencies,
   c_args : build_args,


### PR DESCRIPTION
This replaces the manual printing of the summary with the use of Meson's built-in `summary()` function.
I separated the settings to "Project options" and "Compiler options".

Doing a PR, even if it seems trivial, I might have missed something else :)

edit: obviously this PR got more general than only the usage of `summary()`...